### PR TITLE
Miscellanous fixes: Add missing header, mark parameter as “const”

### DIFF
--- a/lib/uritemplate.hpp
+++ b/lib/uritemplate.hpp
@@ -1,6 +1,7 @@
 #ifndef URITEMPLATECPP_H
 #define URITEMPLATECPP_H
 
+#include <cassert>
 #include <string>
 #include <vector>
 #include <map>

--- a/lib/uritemplate.hpp
+++ b/lib/uritemplate.hpp
@@ -324,7 +324,7 @@ public:
 		}
 	};
 
-	void set(const std::string& key, std::string& val){
+	void set(const std::string& key, const std::string& val){
 		vars.insert(std::pair<std::string,TemplateVar>(key,TemplateVar(val)));
 	};
 


### PR DESCRIPTION
This adds a couple of small fixes:

- 875680b08696644e2c4131489199dd66be795db8 adds a missing `#include <cassert>` which prevents building.
- 389f47a7e1e56714db53a698cb847d4cf03a297b marks the string value passed to `UriTemplate::set()` as `const`, which never gets modified. This makes usage of the API slightly more ergonomic, because it is now possible to pass string literals, e.g. `templ.set("foo", "bar");` 