### PR TITLE
Fix indexing of arrays to use appropriate types

### DIFF
--- a/lib/uritemplate.hpp
+++ b/lib/uritemplate.hpp
@@ -110,8 +110,8 @@ const std::string RESERVED[] = {
 std::string encode_unreserved(const std::string& encodeStr){
 	std::vector<std::string> vecStr;
 	vecStr.resize(encodeStr.size());
-	for (int i = 0; i < encodeStr.size(); i++){
-		vecStr[i] = UNRESERVED[(int)encodeStr[i]];
+	for (size_t i = 0; i < encodeStr.size(); i++){
+		vecStr[i] = UNRESERVED[static_cast<uint8_t>(encodeStr[i])];
 	}
 	std::string result;
 	
@@ -125,8 +125,8 @@ std::string encode_unreserved(const std::string& encodeStr){
 std::string encode_reserved(const std::string& encodeStr){
 	std::vector<std::string> vecStr;
 	vecStr.resize(encodeStr.size());
-	for (int i = 0; i < encodeStr.size(); i++){
-		vecStr[i] = RESERVED[(int)encodeStr[i]];
+	for (size_t i = 0; i < encodeStr.size(); i++){
+		vecStr[i] = RESERVED[static_cast<uint8_t>(encodeStr[i])];
 	}
 	std::string result;
 	


### PR DESCRIPTION
In some platforms the `char` type may be signed, which would result in using negative indexes into the `RESERVED` and `UNRESERVED` string tables, resulting in incorrect expansions of URI templates e.g. when the input data contains non-ASCII characters.

Additionally, change the loop variables to be of type `size_t`, which is the correct type to use when indexing the input strings. This change silences GCC compiler warnings about comparing signed and unsigned values in the loop condition, and about using a signed type as string index.

Thanks to Pablo Saavedra (psaavedra@igalia.com, @psaavedra) who first found the bug.