### PR TITLE
Prevent undefined behavior caused by calling pop_back()

### DIFF
--- a/lib/uritemplate.hpp
+++ b/lib/uritemplate.hpp
@@ -619,7 +619,9 @@ private:
 				result += buildSpecParm.sep;
 			}
 		}
-		result.pop_back();
+		if(!result.empty()){
+			result.pop_back();
+		}
 		return result;
 	};
 private:


### PR DESCRIPTION
Calling pop_back() on an empty string results in undefined behavior.
Thus, check for empty string first.

An empty string can occur in case of undefined variables (e.g. for
testcase  ["O{undef}X", "OX"] in spec-examples-by-section.json from
https://github.com/uri-templates/uritemplate-test/).